### PR TITLE
Invalid source file error with sbt 0.11.2

### DIFF
--- a/src/main/scala/sbtprotobuf/ProtobufPlugin.scala
+++ b/src/main/scala/sbtprotobuf/ProtobufPlugin.scala
@@ -37,7 +37,6 @@ object ProtobufPlugin extends Plugin {
 
   )) ++ Seq[Setting[_]](
     sourceGenerators in Compile <+= (generate in protobufConfig).identity,
-    managedSources in Compile <+= (javaSource in protobufConfig).map(identity(_)),
     cleanFiles <+= (javaSource in protobufConfig).identity,
     libraryDependencies <+= (version in protobufConfig)("com.google.protobuf" % "protobuf-java" % _),
     ivyConfigurations += protobufConfig


### PR DESCRIPTION
Hello - 
I updated my sbt to version 0.11.2 and started to receive an error like below from a test project (ef300d08fd1225104643675ce663f4a8442bd61c):

```
[debug] Calling Scala compiler with arguments  (CompilerInterface):
[debug]         -d
[debug]         /Users/adv/Documents/test-protobuf/target/scala-2.9.1/classes
[debug]         -bootclasspath
[debug]         /Library/Java/JavaVirtualMachines/1.6.0_29-b11-402.jdk/Contents/Classes/jsfd.jar:/Library/Java/JavaVirtualMachines/1.6.0_29-b11-402.jdk/Contents/Classes/classes.jar:/System/Library/Frameworks/JavaVM.framework/Frameworks/JavaRuntimeSupport.framework/Resources/Java/JavaRuntimeSupport.jar:/Library/Java/JavaVirtualMachines/1.6.0_29-b11-402.jdk/Contents/Classes/ui.jar:/Library/Java/JavaVirtualMachines/1.6.0_29-b11-402.jdk/Contents/Classes/laf.jar:/Library/Java/JavaVirtualMachines/1.6.0_29-b11-402.jdk/Contents/Classes/sunrsasign.jar:/Library/Java/JavaVirtualMachines/1.6.0_29-b11-402.jdk/Contents/Classes/jsse.jar:/Library/Java/JavaVirtualMachines/1.6.0_29-b11-402.jdk/Contents/Classes/jce.jar:/Library/Java/JavaVirtualMachines/1.6.0_29-b11-402.jdk/Contents/Classes/charsets.jar:/Users/adv/.sbt/boot/scala-2.9.1/lib/scala-library.jar
[debug]         -classpath
[debug]         /Users/adv/Documents/test-protobuf/target/scala-2.9.1/classes:/Users/adv/.ivy2/cache/com.google.protobuf/protobuf-java/jars/protobuf-java-2.4.1.jar
[debug]         /Users/adv/Documents/test-protobuf/target/scala-2.9.1/src_managed/main/compiled_protobuf
[error] source file '/Users/adv/Documents/test-protobuf/target/scala-2.9.1/src_managed/main/compiled_protobuf' could not be found
[error] one error found
[debug] Compilation failed (CompilerInterface)
[error] {file:/Users/adv/Documents/test-protobuf/}default-77f59c/compile:compile: Compilation failed
[error] Total time: 1 s, completed Dec 15, 2011 4:14:47 PM
```

It seemed to be tripping over the `compiled_protobuf` directory being included, so I removed adding that library on it's own to the managedSources and instead just relied on the javaSource setting to pick up the newly generated files.

I'm not entirely sure if I'm doing this the _correct way_ as I'm pretty lost in SBT 0.11's plugin changes.  So if you can see something that I'm doing wrong, please let me know.

Thanks!
- Aaron
