### PR TITLE
Add `includeFilter` and `excludeFilter` as a posibility to decide what .proto's to generate

### DIFF
--- a/src/main/scala/sbtprotobuf/ProtobufPlugin.scala
+++ b/src/main/scala/sbtprotobuf/ProtobufPlugin.scala
@@ -20,6 +20,7 @@ object ProtobufPlugin extends Plugin {
   lazy val protobufSettings: Seq[Setting[_]] = inConfig(protobufConfig)(Seq[Setting[_]](
     sourceDirectory <<= (sourceDirectory in Compile) { _ / "protobuf" },
     sourceDirectories <<= sourceDirectory apply (_ :: Nil),
+    includeFilter := "*.proto",
     javaSource <<= (sourceManaged in Compile) { _ / "compiled_protobuf" },
     externalIncludePath <<= target(_ / "protobuf_external"),
     protoc := "protoc",
@@ -103,9 +104,9 @@ object ProtobufPlugin extends Plugin {
   }
 
   private def sourceGeneratorTask =
-    (streams, sourceDirectories in protobufConfig, includePaths in protobufConfig, protocOptions in protobufConfig, generatedTargets in protobufConfig, cacheDirectory, protoc) map {
-    (out, srcDirs, includePaths, protocOpts, otherTargets, cache, protocCommand) =>
-      val schemas = srcDirs.toSet[File].flatMap(srcDir => (srcDir ** "*.proto").get.map(_.getAbsoluteFile))
+    (streams, sourceDirectories in protobufConfig, includePaths in protobufConfig, includeFilter in protobufConfig, excludeFilter in protobufConfig, protocOptions in protobufConfig, generatedTargets in protobufConfig, cacheDirectory, protoc) map {
+    (out, srcDirs, includePaths, includeFilter, excludeFilter, protocOpts, otherTargets, cache, protocCommand) =>
+      val schemas = srcDirs.toSet[File].flatMap(srcDir => (srcDir ** (includeFilter -- excludeFilter) ).get.map(_.getAbsoluteFile))
       val cachedCompile = FileFunction.cached(cache / "protobuf", inStyle = FilesInfo.lastModified, outStyle = FilesInfo.exists) { (in: Set[File]) =>
         compile(protocCommand, schemas, includePaths, protocOpts, otherTargets, out.log)
       }


### PR DESCRIPTION
Hello
Thanks for this great plugin.

`includeFilter` and `excludeFilter` are common among plugins that generate code. In this particular case it would allow us to select what protos we want to ignore or "compile".

It's useful especially when having dependencies with a number of protos but we are only interested in only a few. Also when some libraries contain protos and also the java classes and we do not want to re-compile them in order to avoid duplicates in our classpath

An example (that I already use) would be:

`(excludeFilter in PB.protobufConfig) := "value-types.proto" || "documentation.proto"`

That would include all protos except "value-types.proto" and "documentation.proto"

The default setup doesn't modify the existing filter. This is: "*.proto"

For more information about include and exclude filter, please have a look to: http://www.scala-sbt.org/0.13/docs/Howto-Customizing-Paths.html#Include%2Fexclude+files+in+the+source+directory

Regards
