### PR TITLE
Added task scoping to sbt-protobuf

### DIFF
--- a/src/sbt-test/sbt-protobuf/task-scoped/build.sbt
+++ b/src/sbt-test/sbt-protobuf/task-scoped/build.sbt
@@ -1,0 +1,41 @@
+import sbtprotobuf.ScopedProtobufPlugin
+import sbtprotobuf.{ProtobufPlugin=>PB}
+import sbtprotobuf.{ProtobufTestPlugin=>PBT}
+
+PB.protobufSettings
+
+PBT.protobufSettings
+
+version in PB.protobufConfig := "3.1.0"
+
+version in PBT.protobufConfig := (version in PB.protobufConfig).value
+
+libraryDependencies += "com.google.protobuf" % "protobuf-java" % (version in PB.protobufConfig).value % PB.protobufConfig.name
+
+libraryDependencies += "com.google.protobuf" % "protobuf-java" % (version in PBT.protobufConfig).value % PBT.protobufConfig.name
+
+PB.runProtoc in PB.protobufConfig := { args =>
+  com.github.os72.protocjar.Protoc.runProtoc("-v310" +: args.toArray)
+}
+
+PBT.runProtoc in PBT.protobufConfig := (PB.runProtoc in PB.protobufConfig).value
+
+excludeFilter in PB.protobufConfig := "test1.proto"
+
+excludeFilter in PBT.protobufConfig := "test3.proto"
+
+unmanagedResourceDirectories in Compile += (sourceDirectory in PB.protobufConfig).value
+
+unmanagedResourceDirectories in Test += (sourceDirectory in PBT.protobufConfig).value
+
+TaskKey[Unit]("checkJar") := IO.withTemporaryDirectory{ dir =>
+  val files = IO.unzip((packageBin in Compile).value, dir, "*.proto")
+  val expect = Set("test1.proto", "test2.proto").map(dir / _)
+  val testfiles = IO.unzip((packageBin in Test).value, dir, "*.proto")
+  val testexpect = Set("test3.proto", "test4.proto").map(dir / _)
+  assert(files == expect, s"$files $expect")
+  assert(testfiles == testexpect, s"$testfiles $testexpect")
+}
+
+// https://github.com/sbt/sbt-protobuf/issues/37
+mainClass in compile := Some("whatever")

--- a/src/sbt-test/sbt-protobuf/task-scoped/project/plugins.sbt
+++ b/src/sbt-test/sbt-protobuf/task-scoped/project/plugins.sbt
@@ -1,0 +1,9 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                 |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % pluginVersion)
+}
+
+libraryDependencies += "com.github.os72" % "protoc-jar" % "3.1.0.1"

--- a/src/sbt-test/sbt-protobuf/task-scoped/src/main/protobuf/test1.proto
+++ b/src/sbt-test/sbt-protobuf/task-scoped/src/main/protobuf/test1.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package test;
+
+message test1{
+  int32 thing = 1;
+}

--- a/src/sbt-test/sbt-protobuf/task-scoped/src/main/protobuf/test2.proto
+++ b/src/sbt-test/sbt-protobuf/task-scoped/src/main/protobuf/test2.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package test;
+
+// https://github.com/google/protobuf/blob/v3.0.0/src/google/protobuf/timestamp.proto
+
+import "google/protobuf/timestamp.proto";
+
+message test2{
+  google.protobuf.Timestamp time = 1;
+}

--- a/src/sbt-test/sbt-protobuf/task-scoped/src/test/protobuf/test3.proto
+++ b/src/sbt-test/sbt-protobuf/task-scoped/src/test/protobuf/test3.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package test;
+
+message test3{
+  int32 thing = 1;
+}

--- a/src/sbt-test/sbt-protobuf/task-scoped/src/test/protobuf/test4.proto
+++ b/src/sbt-test/sbt-protobuf/task-scoped/src/test/protobuf/test4.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package test;
+
+// https://github.com/google/protobuf/blob/v3.0.0/src/google/protobuf/timestamp.proto
+
+import "google/protobuf/timestamp.proto";
+
+message test4{
+  google.protobuf.Timestamp time = 1;
+}

--- a/src/sbt-test/sbt-protobuf/task-scoped/test
+++ b/src/sbt-test/sbt-protobuf/task-scoped/test
@@ -1,0 +1,45 @@
+> compile
+
+# test for https://github.com/sbt/sbt-protobuf/pull/29
+-$ exists target/scala-2.10/src_managed/main/compiled_protobuf/test/Test1.java
+-$ exists target/scala-2.10/classes/test/Test1.class
+
+# https://github.com/sbt/sbt-protobuf/tree/v0.5.0#declaring-dependencies
+$ exists target/scala-2.10/src_managed/main/compiled_protobuf/test/Test2.java
+$ exists target/scala-2.10/classes/test/Test2.class
+
+# Ensure task is scoped
+-$ exists target/scala-2.10/src_managed/main/compiled_protobuf/test/Test3.java
+-$ exists target/scala-2.10/classes/test/Test3.class
+-$ exists target/scala-2.10/src_managed/main/compiled_protobuf/test/Test4.java
+-$ exists target/scala-2.10/classes/test/Test4.class
+
+# Ensure that test classes weren't generated yet
+-$ exists target/scala-2.10/src_managed/test/compiled_protobuf/test/Test3.java
+-$ exists target/scala-2.10/test-classes/test/Test3.class
+-$ exists target/scala-2.10/src_managed/test/compiled_protobuf/test/Test4.java
+-$ exists target/scala-2.10/test-classes/test/Test4.class
+
+> clean
+
+-$ exists target/scala-2.10/src_managed/main/compiled_protobuf/test/Test2.java
+
+> compile
+> ++ 2.11.8
+> compile
+$ exists target/scala-2.11/src_managed/main/compiled_protobuf/test/Test2.java
+
+# Ensure test-scoped classes are generated with respect to test-scoped settings
+> test
+-$ exists target/scala-2.11/src_managed/test/compiled_protobuf/test/Test3.java
+-$ exists target/scala-2.11/test-classes/test/Test3.class
+$ exists target/scala-2.11/src_managed/test/compiled_protobuf/test/Test4.java
+$ exists target/scala-2.11/test-classes/test/Test4.class
+
+> clean
+-$ exists target/scala-2.11/src_managed/test/compiled_protobuf/test/Test4.java
+
+> compile
+> test
+
+> checkJar


### PR DESCRIPTION
Solves Issue #39, retains all backwards compatibility.

It's not a perfect solution, but it's the best compromise at solving the problem, keeping the performance of the plugin the same (concern listed in #27), and not breaking existing use of the plugin.