### PR TITLE
use slash syntax instead of "in"

### DIFF
--- a/src/sbt-test/sbt-protobuf/basic/build.sbt
+++ b/src/sbt-test/sbt-protobuf/basic/build.sbt
@@ -4,14 +4,14 @@ scalaVersion := "2.10.7"
 
 crossScalaVersions += "2.11.12"
 
-libraryDependencies += "com.google.protobuf" % "protobuf-java" % (version in ProtobufConfig).value % ProtobufConfig.name
+libraryDependencies += "com.google.protobuf" % "protobuf-java" % (ProtobufConfig / version).value % ProtobufConfig.name
 
-excludeFilter in ProtobufConfig := "test1.proto"
+ProtobufConfig / excludeFilter := "test1.proto"
 
-unmanagedResourceDirectories in Compile += (sourceDirectory in ProtobufConfig).value
+(Compile / unmanagedResourceDirectories) += (ProtobufConfig / sourceDirectory).value
 
 TaskKey[Unit]("checkJar") := {
-  val jar = (packageBin in Compile).value
+  val jar = (Compile / packageBin).value
   IO.withTemporaryDirectory{ dir =>
     val files = IO.unzip(jar, dir, "*.proto")
     val expect = Set("test1.proto", "test2.proto").map(dir / _)
@@ -20,4 +20,4 @@ TaskKey[Unit]("checkJar") := {
 }
 
 // https://github.com/sbt/sbt-protobuf/issues/37
-mainClass in compile := Some("whatever")
+compile / mainClass := Some("whatever")

--- a/src/sbt-test/sbt-protobuf/multi-project/build.sbt
+++ b/src/sbt-test/sbt-protobuf/multi-project/build.sbt
@@ -8,5 +8,5 @@ val foo = project.settings(
 
 val bar = project.settings(
   commonSettings,
-  protobufIncludePaths in ProtobufConfig += (sourceDirectory in ProtobufConfig in foo).value
+  (ProtobufConfig / protobufIncludePaths) += (foo / ProtobufConfig / sourceDirectory).value
 ).dependsOn(foo).enablePlugins(ProtobufPlugin)

--- a/src/sbt-test/sbt-protobuf/protojar/build.sbt
+++ b/src/sbt-test/sbt-protobuf/protojar/build.sbt
@@ -4,16 +4,16 @@ version := "0.1.0-SNAPSHOT"
 
 scalaVersion := "2.10.7"
 
-libraryDependencies += "com.google.protobuf" % "protobuf-java" % (version in ProtobufConfig).value % ProtobufConfig.name
+libraryDependencies += "com.google.protobuf" % "protobuf-java" % (ProtobufConfig / version).value % ProtobufConfig.name
 
-protobufRunProtoc in ProtobufConfig := { args =>
+ProtobufConfig / protobufRunProtoc := { args =>
   com.github.os72.protocjar.Protoc.runProtoc("-v390" +: args.toArray)
 }
 
-addArtifact(artifact in (ProtobufConfig, protobufPackage), protobufPackage in ProtobufConfig)
+addArtifact(ProtobufConfig / protobufPackage / artifact, ProtobufConfig / protobufPackage)
 
 TaskKey[Unit]("checkJar") := {
-  val jar = (protobufPackage in ProtobufConfig).value
+  val jar = (ProtobufConfig / protobufPackage).value
   IO.withTemporaryDirectory{ dir =>
     val files = IO.unzip(jar, dir)
     val expect = Set(dir / "test1.proto", dir / "META-INF" / "MANIFEST.MF")

--- a/src/sbt-test/sbt-protobuf/task-scoped/build.sbt
+++ b/src/sbt-test/sbt-protobuf/task-scoped/build.sbt
@@ -6,25 +6,25 @@ crossScalaVersions += "2.11.12"
 
 enablePlugins(ProtobufPlugin, ProtobufTestPlugin)
 
-version in PBT.ProtobufConfig := (version in ProtobufConfig).value
+(PBT.ProtobufConfig / version) := (ProtobufConfig / version).value
 
-libraryDependencies += "com.google.protobuf" % "protobuf-java" % (version in ProtobufConfig).value % ProtobufConfig.name
+libraryDependencies += "com.google.protobuf" % "protobuf-java" % (ProtobufConfig / version).value % ProtobufConfig.name
 
-libraryDependencies += "com.google.protobuf" % "protobuf-java" % (version in PBT.ProtobufConfig).value % PBT.ProtobufConfig.name
+libraryDependencies += "com.google.protobuf" % "protobuf-java" % (PBT.ProtobufConfig / version).value % PBT.ProtobufConfig.name
 
-PBT.protobufRunProtoc in PBT.ProtobufConfig := (protobufRunProtoc in ProtobufConfig).value
+(PBT.ProtobufConfig / PBT.protobufRunProtoc) := (ProtobufConfig / protobufRunProtoc).value
 
-excludeFilter in ProtobufConfig := "test1.proto"
+ProtobufConfig / excludeFilter := "test1.proto"
 
-excludeFilter in PBT.ProtobufConfig := "test3.proto"
+PBT.ProtobufConfig / excludeFilter := "test3.proto"
 
-unmanagedResourceDirectories in Compile += (sourceDirectory in ProtobufConfig).value
+(Compile / unmanagedResourceDirectories) += (ProtobufConfig / sourceDirectory).value
 
-unmanagedResourceDirectories in Test += (sourceDirectory in PBT.ProtobufConfig).value
+(Test / unmanagedResourceDirectories) += (PBT.ProtobufConfig / sourceDirectory).value
 
 TaskKey[Unit]("checkJar") := {
-  val compileJar = (packageBin in Compile).value
-  val testJar = (packageBin in Test).value
+  val compileJar = (Compile / packageBin).value
+  val testJar = (Test / packageBin).value
 
   IO.withTemporaryDirectory{ dir =>
     val files = IO.unzip(compileJar, dir, "*.proto")
@@ -37,4 +37,4 @@ TaskKey[Unit]("checkJar") := {
 }
 
 // https://github.com/sbt/sbt-protobuf/issues/37
-mainClass in compile := Some("whatever")
+compile / mainClass := Some("whatever")


### PR DESCRIPTION
https://github.com/sbt/sbt/commit/e6fec6b1db5f212a74bf5e3766b9b70f2d983f24
https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash