### PR TITLE
protobufExcludeOutputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ All settings and tasks are in the `protobuf` scope. If you want to execute the `
     <td><code>(file(</code>java source directory based on <code>ProtobufConfig / javaSource</code>), <code>"*.java")</code></td>
     <td>the list of target directories and source file globs for the generated files</td>
 </tr>
+<tr>
+    <td>protobufExcludeOutputs</td>
+    <td></td>
+    <td><code>Seq(Glob((ProtobufConfig / javaSource).value) / "com" / "google" / "protobuf" / "*.java")</code></td>
+    <td>the list of glob expressions to exclude from the generated files</td>
+</tr>
 </table>
 
 ## Tasks

--- a/src/sbt-test/sbt-protobuf/exclude/build.sbt
+++ b/src/sbt-test/sbt-protobuf/exclude/build.sbt
@@ -1,0 +1,20 @@
+enablePlugins(ProtobufPlugin)
+version := "0.1.0-SNAPSHOT"
+name := "exclude-test"
+scalaVersion := "2.13.13"
+
+libraryDependencies ++= Seq(
+  "com.google.protobuf" % "protobuf-java" % (ProtobufConfig / version).value % ProtobufConfig,
+)
+
+ProtobufConfig / sourceDirectories += (ProtobufConfig / protobufExternalIncludePath).value
+
+TaskKey[Unit]("checkJar") := {
+  val jar = (Compile / packageBin).value
+  IO.withTemporaryDirectory{ dir =>
+    val files = IO.unzip(jar, dir)
+    val expect = Set(dir / "META-INF" / "MANIFEST.MF")
+    assert(files == expect, s"""actual = $files,
+expected = $expect""")
+  }
+}

--- a/src/sbt-test/sbt-protobuf/exclude/project/plugins.sbt
+++ b/src/sbt-test/sbt-protobuf/exclude/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.github.sbt" % "sbt-protobuf" % pluginVersion)
+}

--- a/src/sbt-test/sbt-protobuf/exclude/test
+++ b/src/sbt-test/sbt-protobuf/exclude/test
@@ -1,0 +1,1 @@
+> checkJar

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,13 @@
+// So that publishLocal doesn't continuously create new versions
+def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
+  val snapshotSuffix =
+    if (out.isSnapshot()) "-SNAPSHOT"
+    else ""
+  out.ref.dropPrefix + snapshotSuffix
+}
+def fallbackVersion(d: java.util.Date): String = s"HEAD-${sbtdynver.DynVer timestamp d}"
+ThisBuild / version := dynverGitDescribeOutput.value.mkVersion(versionFmt, fallbackVersion(dynverCurrentDate.value))
+ThisBuild / dynver := {
+  val d = new java.util.Date
+  sbtdynver.DynVer.getGitDescribeOutput(d).mkVersion(versionFmt, fallbackVersion(d))
+}


### PR DESCRIPTION
## Problem
When compiling complex protobuf schema, you often run into a situation where you need some external schema during the compilation, but you don't necessarily want to include the resulting Java output as your own output because there's already a precompiled or well-known bytecode version of the class.

A good example of this is classes under com/google/protobuf.

## Solution
As a workaround to this situation, this implements protobufExcludeOutputs, which is a seq of glob expression.
As a demonstration this key is initialized to be:
`Glob((ProtobufConfig / javaSource).value) / "com" / "google" / "protobuf" / "*.java"`. This can include `com/google/protobuf` into protoc but will exclude it from during source generation since there's a well-known precompiled artifact `"com.google.protobuf" % "protobuf-java"`.