### PR TITLE
protobufExcludeFilters

### DIFF
--- a/src/sbt-test/sbt-protobuf/exclude/build.sbt
+++ b/src/sbt-test/sbt-protobuf/exclude/build.sbt
@@ -1,0 +1,20 @@
+enablePlugins(ProtobufPlugin)
+version := "0.1.0-SNAPSHOT"
+name := "exclude-test"
+scalaVersion := "2.13.13"
+
+libraryDependencies ++= Seq(
+  "com.google.protobuf" % "protobuf-java" % (ProtobufConfig / version).value % ProtobufConfig,
+)
+
+ProtobufConfig / sourceDirectories += (ProtobufConfig / protobufExternalIncludePath).value
+
+TaskKey[Unit]("checkJar") := {
+  val jar = (Compile / packageBin).value
+  IO.withTemporaryDirectory{ dir =>
+    val files = IO.unzip(jar, dir)
+    val expect = Set(dir / "META-INF" / "MANIFEST.MF")
+    assert(files == expect, s"""actual = $files,
+expected = $expect""")
+  }
+}

--- a/src/sbt-test/sbt-protobuf/exclude/project/plugins.sbt
+++ b/src/sbt-test/sbt-protobuf/exclude/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.github.sbt" % "sbt-protobuf" % pluginVersion)
+}

--- a/src/sbt-test/sbt-protobuf/exclude/test
+++ b/src/sbt-test/sbt-protobuf/exclude/test
@@ -1,0 +1,1 @@
+> checkJar

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,13 @@
+// So that publishLocal doesn't continuously create new versions
+def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
+  val snapshotSuffix =
+    if (out.isSnapshot()) "-SNAPSHOT"
+    else ""
+  out.ref.dropPrefix + snapshotSuffix
+}
+def fallbackVersion(d: java.util.Date): String = s"HEAD-${sbtdynver.DynVer timestamp d}"
+ThisBuild / version := dynverGitDescribeOutput.value.mkVersion(versionFmt, fallbackVersion(dynverCurrentDate.value))
+ThisBuild / dynver := {
+  val d = new java.util.Date
+  sbtdynver.DynVer.getGitDescribeOutput(d).mkVersion(versionFmt, fallbackVersion(d))
+}


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt-protobuf/issues/98

## Problem
When compiling complex protobuf schema, you often
run into a situation where you need some external
schema during the compilation, but you don't
necessarily want to include the resulting Java
output as your own output because there's already
a precompiled or well-known bytecode version of
the class.
A good example of this is classes under com/google/protobuf, but there are others as well.

In theory #29 has added excludeFilter support,
but in practice sbt's file filter doesn't work
for directory name matching.

## Solution
This reimplements the protobuf file filtering
using the new Glob, which can match directory names.

As a demonstration, `protobufExcludeFilters` is
initialized to glob `Glob(d.toPath()) / "google" / "protobuf" / "*.proto"`. This will filter out protobuf sources which
are precompiled in "com.google.protobuf" % "protobuf-java".