### PR TITLE
Invalidate protobuf cache when generation inputs change

### DIFF
--- a/src/main/scala/sbtprotobuf/ProtobufPlugin.scala
+++ b/src/main/scala/sbtprotobuf/ProtobufPlugin.scala
@@ -228,6 +228,9 @@ class ScopedProtobufPlugin(configuration: Configuration, private[sbtprotobuf] va
 
   private[this] def sourceGeneratorTask =
     Def.task {
+      import sbt.util.CacheImplicits._
+      import sbt.util.HashFileInfo
+
       val out     = streams.value
       val schemas = protobufSources.value.toSet[File].map(_.getAbsoluteFile)
       // Include Scala binary version like "_2.11" for cross building.
@@ -236,16 +239,40 @@ class ScopedProtobufPlugin(configuration: Configuration, private[sbtprotobuf] va
       val includePaths = (ProtobufConfig / protobufIncludePaths).value
       val options = (ProtobufConfig / protobufProtocOptions).value
       val targets = (ProtobufConfig / protobufGeneratedTargets).value
-      val cachedCompile = FileFunction.cached(cacheFile, inStyle = FilesInfo.lastModified, outStyle = FilesInfo.exists) { (in: Set[File]) =>
-        compile(
-          protocCommand = runProtoc,
-          schemas = schemas,
-          includePaths = includePaths,
-          protocOptions = options,
-          generatedTargets = targets,
-          log = out.log)
+
+      // Imports, including transitive imports, affect generation without being compiled themselves.
+      val inputs = schemas ++ includePaths.flatMap(dir => (dir ** "*.proto").get())
+      val settings = Seq(
+        schemas.toSeq.map(_.getCanonicalPath).sorted,
+        includePaths.map(_.getCanonicalPath),
+        options,
+        targets.flatMap { case (dir, pattern) => Seq(dir.getCanonicalPath, pattern) },
+        Seq(
+          version.value,
+          protobufUseSystemProtoc.value.toString,
+          protobufProtoc.value,
+          protobufGrpcEnabled.value.toString,
+          protobufGrpcVersion.value,
+        ),
+      )
+      val cachedOutputs = Tracked.lastOutput(cacheFile / "outputs") { (changed: Boolean, previous: Option[Set[File]]) =>
+        previous match {
+          case Some(files) if !changed && files.forall(_.exists()) => files
+          case _ =>
+            compile(
+              protocCommand = runProtoc,
+              schemas = schemas,
+              includePaths = includePaths,
+              protocOptions = options,
+              generatedTargets = targets,
+              log = out.log)
+        }
       }
-      cachedCompile(schemas).toSeq
+      val cachedGeneration = Tracked.inputChanged(cacheFile / "inputs") {
+        (changed: Boolean, _: (Seq[Seq[String]], FilesInfo[HashFileInfo])) => cachedOutputs(changed)
+      }
+      // Hash contents so re-extracting unchanged dependencies does not force regeneration.
+      cachedGeneration((settings, FileInfo.hash(inputs))).toSeq
     }
 
   private[this] def unpackDependenciesTask = Def.task {

--- a/src/sbt-test/sbt-protobuf/cache-imports/alternate/dep.proto
+++ b/src/sbt-test/sbt-protobuf/cache-imports/alternate/dep.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+package dep;
+option java_package = "dep.alternate";
+import "nested/value.proto";
+message Payload { Value value = 1; }

--- a/src/sbt-test/sbt-protobuf/cache-imports/build.sbt
+++ b/src/sbt-test/sbt-protobuf/cache-imports/build.sbt
@@ -1,0 +1,58 @@
+import sbtcompat.PluginCompat._
+
+enablePlugins(ProtobufPlugin)
+
+scalaVersion := "2.12.21"
+
+ProtobufConfig / protobufIncludePaths ++= Def.uncached(Seq(
+  baseDirectory.value / "imports",
+  baseDirectory.value / "alternate",
+))
+
+ProtobufConfig / protobufRunProtoc := Def.uncached {
+  val run = (ProtobufConfig / protobufRunProtoc).value
+  val count = baseDirectory.value / "runs"
+  (args: Seq[String]) => {
+    IO.append(count, "run\n")
+    run(args)
+  }
+}
+
+InputKey[Unit]("checkRuns") := Def.uncached {
+  val expected = sbt.complete.DefaultParsers.spaceDelimited("count").parsed.head.toInt
+  val actual = IO.readLines(baseDirectory.value / "runs").size
+  assert(actual == expected, s"Expected $expected protoc runs, got $actual")
+}
+
+InputKey[Unit]("checkPackage") := Def.uncached {
+  val expected = sbt.complete.DefaultParsers.spaceDelimited("package").parsed.head
+  val files = ((ProtobufConfig / javaSource).value ** "*.java").get()
+  assert(files.size == 1, s"Imported schemas must not be compiled: $files")
+  assert(IO.read(files.head).contains(expected + ".Dep.Payload"))
+}
+
+TaskKey[Unit]("touchImport") := Def.uncached {
+  val source = baseDirectory.value / "imports" / "dep.proto"
+  java.nio.file.Files.setLastModifiedTime(
+    source.toPath,
+    java.nio.file.attribute.FileTime.fromMillis(source.lastModified() + 10000),
+  )
+}
+
+TaskKey[Unit]("changeImport") := Def.uncached {
+  val source = baseDirectory.value / "imports" / "dep.proto"
+  val modified = java.nio.file.Files.getLastModifiedTime(source.toPath)
+  IO.write(source, IO.read(source).replace("dep.v1", "dep.v2"))
+  java.nio.file.Files.setLastModifiedTime(source.toPath, modified)
+}
+
+TaskKey[Unit]("changeTransitiveImport") := Def.uncached {
+  val source = baseDirectory.value / "imports" / "nested" / "value.proto"
+  IO.write(source, IO.read(source).replace("string value", "bytes value"))
+}
+
+TaskKey[Unit]("deleteOutputs") := Def.uncached(IO.delete((ProtobufConfig / javaSource).value))
+
+TaskKey[Unit]("deleteTransitiveImport") := Def.uncached {
+  IO.delete(baseDirectory.value / "imports" / "nested" / "value.proto")
+}

--- a/src/sbt-test/sbt-protobuf/cache-imports/imports/dep.proto
+++ b/src/sbt-test/sbt-protobuf/cache-imports/imports/dep.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+package dep;
+option java_package = "dep.v1";
+import "nested/value.proto";
+message Payload { Value value = 1; }

--- a/src/sbt-test/sbt-protobuf/cache-imports/imports/nested/value.proto
+++ b/src/sbt-test/sbt-protobuf/cache-imports/imports/nested/value.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+package dep;
+message Value { string value = 1; }

--- a/src/sbt-test/sbt-protobuf/cache-imports/project/plugins.sbt
+++ b/src/sbt-test/sbt-protobuf/cache-imports/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.github.sbt" % "sbt-protobuf" % sys.props("plugin.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/sbt-protobuf/cache-imports/src/main/protobuf/root.proto
+++ b/src/sbt-test/sbt-protobuf/cache-imports/src/main/protobuf/root.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+package test;
+import "dep.proto";
+message Root { dep.Payload payload = 1; }

--- a/src/sbt-test/sbt-protobuf/cache-imports/test
+++ b/src/sbt-test/sbt-protobuf/cache-imports/test
@@ -1,0 +1,33 @@
+> Protobuf/protobufGenerate
+> checkRuns 1
+> checkPackage dep.v1
+
+# Unchanged contents must keep the cache, even if extraction updates timestamps.
+> Protobuf/protobufGenerate
+> touchImport
+> Protobuf/protobufGenerate
+> checkRuns 1
+
+# Imported content changes must invalidate the cache even with the same timestamp.
+> changeImport
+> Protobuf/protobufGenerate
+> checkRuns 2
+> checkPackage dep.v2
+
+> changeTransitiveImport
+> Protobuf/protobufGenerate
+> checkRuns 3
+
+# Include precedence matters even when the set of input files is unchanged.
+> set { import sbtcompat.PluginCompat._; ProtobufConfig / protobufIncludePaths := Def.uncached((ProtobufConfig / protobufIncludePaths).value.reverse) }
+> Protobuf/protobufGenerate
+> checkRuns 4
+> checkPackage dep.alternate
+
+> deleteOutputs
+> Protobuf/protobufGenerate
+> checkRuns 5
+
+# Missing imports must be reported instead of returning old generated files.
+> deleteTransitiveImport
+-> Protobuf/protobufGenerate

--- a/src/sbt-test/sbt-protobuf/cache-options/build.sbt
+++ b/src/sbt-test/sbt-protobuf/cache-options/build.sbt
@@ -1,0 +1,37 @@
+import sbtcompat.PluginCompat._
+
+enablePlugins(ProtobufPlugin)
+
+scalaVersion := "2.12.21"
+
+ProtobufConfig / protobufRunProtoc := Def.uncached {
+  val run = (ProtobufConfig / protobufRunProtoc).value
+  val count = baseDirectory.value / "runs"
+  (args: Seq[String]) => {
+    IO.append(count, "run\n")
+    run(args)
+  }
+}
+
+InputKey[Unit]("checkRuns") := Def.uncached {
+  val expected = sbt.complete.DefaultParsers.spaceDelimited("count").parsed.head.toInt
+  val actual = IO.readLines(baseDirectory.value / "runs").size
+  assert(actual == expected, s"Expected $expected protoc runs, got $actual")
+}
+
+InputKey[Unit]("checkRuntime") := Def.uncached {
+  val expected = sbt.complete.DefaultParsers.spaceDelimited("runtime").parsed.head
+  val files = ((ProtobufConfig / javaSource).value ** "*.java").get()
+  assert(files.nonEmpty)
+  assert(files.forall(f => IO.read(f).contains("com.google.protobuf." + expected)))
+}
+
+TaskKey[Unit]("checkExcluded") := Def.uncached {
+  val files = (ProtobufConfig / protobufGenerate).value
+  assert(files.size == 1, s"Expected only root.proto to be compiled: $files")
+  assert(!((ProtobufConfig / javaSource).value / "test" / "ExtraOuterClass.java").exists())
+}
+
+TaskKey[Unit]("checkEmptyTargets") := Def.uncached {
+  assert((ProtobufConfig / protobufGenerate).value.isEmpty)
+}

--- a/src/sbt-test/sbt-protobuf/cache-options/project/plugins.sbt
+++ b/src/sbt-test/sbt-protobuf/cache-options/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.github.sbt" % "sbt-protobuf" % sys.props("plugin.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/sbt-protobuf/cache-options/src/main/protobuf/extra.proto
+++ b/src/sbt-test/sbt-protobuf/cache-options/src/main/protobuf/extra.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+package test;
+message Extra { string value = 1; }

--- a/src/sbt-test/sbt-protobuf/cache-options/src/main/protobuf/root.proto
+++ b/src/sbt-test/sbt-protobuf/cache-options/src/main/protobuf/root.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+package test;
+message Root { string value = 1; }

--- a/src/sbt-test/sbt-protobuf/cache-options/test
+++ b/src/sbt-test/sbt-protobuf/cache-options/test
@@ -1,0 +1,26 @@
+> Protobuf/protobufGenerate
+> checkRuns 1
+> checkRuntime GeneratedMessageV3
+
+> set ProtobufConfig / protobufProtocOptions := Seq("--java_out=lite:" + (ProtobufConfig / javaSource).value.getCanonicalPath)
+> Protobuf/protobufGenerate
+> checkRuns 2
+> checkRuntime GeneratedMessageLite
+
+> Protobuf/protobufGenerate
+> checkRuns 2
+
+# Excluded schemas remain on the include path but must stop generating outputs.
+> set ProtobufConfig / protobufExcludeFilters += Glob((ProtobufConfig / sourceDirectory).value.toPath) / "extra.proto"
+> checkExcluded
+> checkRuns 3
+
+> set ProtobufConfig / javaSource := target.value / "moved-protobuf"
+> Protobuf/protobufGenerate
+> checkRuns 4
+> checkRuntime GeneratedMessageLite
+
+# Output globs must invalidate the cache independently of protoc options.
+> set ProtobufConfig / protobufGeneratedTargets := Seq(((ProtobufConfig / javaSource).value, "*.scala"))
+> checkEmptyTargets
+> checkRuns 5


### PR DESCRIPTION
Fixes #302.

Track schema contents (including imports), selected sources, ordered include paths, compiler settings, options and output targets. Keep unchanged builds cached and regenerate missing outputs.

Adds two scripted regression tests. Validated with `sbt test scripted` and `sbt '++ 3.x' test scriptedTestSbt2`.
