### PR TITLE
Remove obsolete protobuf dependency schemas

### DIFF
--- a/src/main/scala/sbtprotobuf/ProtobufPlugin.scala
+++ b/src/main/scala/sbtprotobuf/ProtobufPlugin.scala
@@ -102,7 +102,7 @@ class ScopedProtobufPlugin(configuration: Configuration, private[sbtprotobuf] va
       dirs.map(d => Glob(d.toPath()) / "google" / "protobuf" / "*.proto")
     },
     javaSource := { (configuration / sourceManaged).value / "compiled_protobuf" },
-    protobufExternalIncludePath := (target.value / "protobuf_external"),
+    protobufExternalIncludePath := (target.value / s"protobuf_external$configurationPostfix"),
     protobufProtoc := "protoc",
     protobufRunProtoc := {
       // keep this if-expression top-level for selective functor
@@ -219,11 +219,16 @@ class ScopedProtobufPlugin(configuration: Configuration, private[sbtprotobuf] va
 
   private[this] def unpack(deps: Seq[FileRef], extractTarget: File, log: Logger, converter: FileConverter): Seq[File] = {
     IO.createDirectory(extractTarget)
-    deps.flatMap { dep =>
+    val extractedFiles = deps.flatMap { dep =>
       val seq = IO.unzip(ProtobufPluginCompat.toFile(dep, converter), extractTarget, "*.proto").toSeq
       if (!seq.isEmpty) log.debug("Extracted " + seq.mkString("\n * ", "\n * ", ""))
       seq
     }
+    // Prune obsolete schemas only after all dependencies have been extracted successfully.
+    val currentFiles = extractedFiles.toSet
+    val obsoleteFiles = (extractTarget ** "*.proto").get().filter(f => f.isFile && !currentFiles(f))
+    IO.delete(obsoleteFiles)
+    extractedFiles
   }
 
   private[this] def sourceGeneratorTask =

--- a/src/sbt-test/sbt-protobuf/dependency-cleanup/build.sbt
+++ b/src/sbt-test/sbt-protobuf/dependency-cleanup/build.sbt
@@ -1,0 +1,80 @@
+import sbtcompat.PluginCompat._
+import sbtprotobuf.ProtobufTestPlugin.{Keys => PBT}
+
+enablePlugins(ProtobufPlugin, ProtobufTestPlugin)
+
+scalaVersion := "2.12.21"
+
+Compile / unmanagedBase := baseDirectory.value / "dependency-jars"
+Test / unmanagedBase := baseDirectory.value / "test-jars"
+
+ProtobufConfig / managedClasspath := Def.uncached((Compile / unmanagedJars).value)
+PBT.ProtobufConfig / managedClasspath := Def.uncached((Test / unmanagedJars).value)
+
+def relativePath(base: File, file: File): String =
+  IO.relativize(base, file).get.replace(java.io.File.separatorChar, '/')
+
+def installJar(base: File, variant: String, jar: File): Unit = {
+  val source = base / "testdata" / variant
+  val mappings = (source ** "*").get().filter(_.isFile).map(f => f -> relativePath(source, f))
+  IO.createDirectory(jar.getParentFile)
+  IO.delete(jar)
+  IO.zip(mappings, jar, Some(0L))
+}
+
+TaskKey[Unit]("initDependencies") := Def.uncached {
+  val base = baseDirectory.value
+  installJar(base, "v1", base / "dependency-jars" / "main.jar")
+  installJar(base, "other", base / "dependency-jars" / "other.jar")
+  installJar(base, "test", base / "test-jars" / "test.jar")
+  IO.write((ProtobufConfig / protobufExternalIncludePath).value / "keep.txt", "keep")
+}
+
+TaskKey[Unit]("upgradeDependency") := Def.uncached {
+  val base = baseDirectory.value
+  installJar(base, "v2", base / "dependency-jars" / "main.jar")
+  IO.delete((ProtobufConfig / javaSource).value)
+}
+
+InputKey[Unit]("checkSchemas") := Def.uncached {
+  val expected = sbt.complete.DefaultParsers.spaceDelimited("schema").parsed.toSet
+  val unpacked = (ProtobufConfig / protobufUnpackDependencies).value
+  val actual = (unpacked.dir ** "*.proto").get().map(relativePath(unpacked.dir, _)).toSet
+  val reported = unpacked.files.map(relativePath(unpacked.dir, _)).toSet
+  assert(actual == expected, s"Extracted schemas: $actual; expected: $expected")
+  assert(reported == expected, s"Reported schemas: $reported; expected: $expected")
+  assert(IO.read(unpacked.dir / "keep.txt") == "keep")
+  assert(!(unpacked.dir / "ignored.txt").exists())
+}
+
+TaskKey[Unit]("checkUpdatedSchema") := Def.uncached {
+  val source = (ProtobufConfig / protobufExternalIncludePath).value / "shared.proto"
+  assert(IO.read(source).contains("version_two"))
+}
+
+TaskKey[Unit]("checkTestSchemas") := Def.uncached {
+  val unpacked = (PBT.ProtobufConfig / PBT.protobufUnpackDependencies).value
+  val mainDir = (ProtobufConfig / protobufExternalIncludePath).value
+  assert(unpacked.dir != mainDir, "Configurations must have separate extraction directories")
+  assert(unpacked.files.map(_.getName).toSet == Set("test-only.proto"))
+  assert((mainDir / "new.proto").isFile)
+}
+
+TaskKey[Unit]("useNewSchema") := Def.uncached {
+  val source = baseDirectory.value / "src" / "main" / "protobuf" / "root.proto"
+  IO.write(source, IO.read(source).replace("legacy/old.proto", "new.proto").replace("dep.Old", "dep.New"))
+}
+
+TaskKey[Unit]("removeOtherDependency") := Def.uncached {
+  IO.delete(baseDirectory.value / "dependency-jars" / "other.jar")
+}
+
+TaskKey[Unit]("removeAllDependencies") := Def.uncached {
+  IO.delete(baseDirectory.value / "dependency-jars")
+  IO.delete((ProtobufConfig / javaSource).value)
+}
+
+TaskKey[Unit]("checkTestRetained") := Def.uncached {
+  val dir = (PBT.ProtobufConfig / PBT.protobufExternalIncludePath).value
+  assert((dir / "test-only.proto").isFile, "Main cleanup removed a test dependency")
+}

--- a/src/sbt-test/sbt-protobuf/dependency-cleanup/project/plugins.sbt
+++ b/src/sbt-test/sbt-protobuf/dependency-cleanup/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.github.sbt" % "sbt-protobuf" % sys.props("plugin.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/sbt-protobuf/dependency-cleanup/src/main/protobuf/root.proto
+++ b/src/sbt-test/sbt-protobuf/dependency-cleanup/src/main/protobuf/root.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+package test;
+import "legacy/old.proto";
+message Root { dep.Old value = 1; }

--- a/src/sbt-test/sbt-protobuf/dependency-cleanup/test
+++ b/src/sbt-test/sbt-protobuf/dependency-cleanup/test
@@ -1,0 +1,25 @@
+> initDependencies
+> checkSchemas legacy/old.proto shared.proto other.proto
+> Protobuf/protobufGenerate
+
+# Replacing a JAR removes obsolete schemas while retaining other dependencies.
+> upgradeDependency
+> checkSchemas new.proto shared.proto other.proto
+> checkUpdatedSchema
+> checkTestSchemas
+-> Protobuf/protobufGenerate
+
+> useNewSchema
+> Protobuf/protobufGenerate
+
+# Removing dependencies, including the last one, must remove their schemas.
+> removeOtherDependency
+> checkSchemas new.proto shared.proto
+> removeAllDependencies
+> checkSchemas
+> checkTestRetained
+-> Protobuf/protobufGenerate
+
+# Extraction recovers after an empty dependency set.
+> initDependencies
+> checkSchemas legacy/old.proto shared.proto other.proto

--- a/src/sbt-test/sbt-protobuf/dependency-cleanup/testdata/other/other.proto
+++ b/src/sbt-test/sbt-protobuf/dependency-cleanup/testdata/other/other.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+package dep;
+message Other { string value = 1; }

--- a/src/sbt-test/sbt-protobuf/dependency-cleanup/testdata/test/test-only.proto
+++ b/src/sbt-test/sbt-protobuf/dependency-cleanup/testdata/test/test-only.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+package dep;
+message TestOnly { string value = 1; }

--- a/src/sbt-test/sbt-protobuf/dependency-cleanup/testdata/v1/legacy/old.proto
+++ b/src/sbt-test/sbt-protobuf/dependency-cleanup/testdata/v1/legacy/old.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+package dep;
+message Old { string value = 1; }

--- a/src/sbt-test/sbt-protobuf/dependency-cleanup/testdata/v1/shared.proto
+++ b/src/sbt-test/sbt-protobuf/dependency-cleanup/testdata/v1/shared.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+package dep;
+message Shared { string version_one = 1; }

--- a/src/sbt-test/sbt-protobuf/dependency-cleanup/testdata/v2/ignored.txt
+++ b/src/sbt-test/sbt-protobuf/dependency-cleanup/testdata/v2/ignored.txt
@@ -1,0 +1,1 @@
+This entry must not be extracted.

--- a/src/sbt-test/sbt-protobuf/dependency-cleanup/testdata/v2/new.proto
+++ b/src/sbt-test/sbt-protobuf/dependency-cleanup/testdata/v2/new.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+package dep;
+message New { string value = 1; }

--- a/src/sbt-test/sbt-protobuf/dependency-cleanup/testdata/v2/shared.proto
+++ b/src/sbt-test/sbt-protobuf/dependency-cleanup/testdata/v2/shared.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+package dep;
+message Shared { string version_two = 1; }


### PR DESCRIPTION
Fixes #304.

Prune obsolete dependency schemas after successful extraction, including when all dependencies are removed. Isolate default extraction directories by configuration so cleanup cannot remove another configuration's schemas.

Adds a scripted regression covering replacements, removals and recovery. Validated on sbt 1.13.0 and 2.0.8.
